### PR TITLE
delete button on orders page works, firebase keys added

### DIFF
--- a/api/ordersData.js
+++ b/api/ordersData.js
@@ -18,5 +18,15 @@ const getOrders = () => new Promise((resolve, reject) => {
     })
     .catch(reject);
 });
+const deleteOrders = (firebaseKey) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/orders/${firebaseKey}.json`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+  }).then((response) => response.json())
+    .then(resolve)
+    .catch(reject);
+});
 
-export default getOrders;
+export { deleteOrders, getOrders };

--- a/events/domEvents.js
+++ b/events/domEvents.js
@@ -1,10 +1,20 @@
-import getOrders from '../api/ordersData';
+/* eslint-disable no-alert */
+import { getOrders, deleteOrders } from '../api/ordersData';
 import { showOrders } from '../pages/orders';
 
 const domEvents = (user) => {
   document.querySelector('#main-container').addEventListener('click', (e) => {
     if (e.target.id.includes('home-view-orders-btn')) {
       getOrders(user).then((array) => showOrders(array));
+    }
+
+    if (e.target.id.includes('order-delete')) {
+      if (window.confirm('Do you want to delete?')) {
+        const [, firebaseKey] = e.target.id.split('--');
+        deleteOrders(firebaseKey).then(() => {
+          getOrders(user).then((array) => showOrders(array));
+        });
+      }
     }
   });
 };

--- a/pages/orders.js
+++ b/pages/orders.js
@@ -21,9 +21,9 @@ const showOrders = (array) => {
               <p class="card-text bold">${item.phone}</p>
               <p class="card-text bold">${item.email}</p>
               <p class="card-text bold">${item.orderType}</p>
-              <a href="#" id='order-details' class="card-link">Details</a>
-              <a href="#" id='order-edit' class="card-link">Edit</a>
-              <a href="#" id='order-delete' class="card-link">Delete</a>
+              <a href="#" id='order-details--${item.firebaseKey}' class="card-link">Details</a>
+              <a href="#" id='order-edit--${item.firebaseKey}' class="card-link">Edit</a>
+              <a href="#" id='order-delete--${item.firebaseKey}' class="card-link">Delete</a>
           </div>
         </div>
         `;

--- a/utils/sample_data/items.json
+++ b/utils/sample_data/items.json
@@ -1,51 +1,51 @@
 {
   "-NeAr6hvZQF-rJYqs8rD": {
-    "firebaseKey": 1,
+    "firebaseKey": "-NeAr6hvZQF-rJYqs8rD",
     "name": "cold pizza",
     "price": 38.21
   },
   "-NeAr6hvZQF-rJYqs8rE": {
-    "firebaseKey": 2,
+    "firebaseKey": "-NeAr6hvZQF-rJYqs8rE",
     "name": "honey bbq boneless",
     "price": 33.87
   },
   "-NeAr6hvZQF-rJYqs8rF": {
-    "firebaseKey": 3,
+    "firebaseKey": "-NeAr6hvZQF-rJYqs8rF",
     "name": "caribbean jerk traditional",
     "price": 10.81
   },
   "-NeAr6hwseNNLkaCWYd5": {
-    "firebaseKey": 4,
+    "firebaseKey": "-NeAr6hwseNNLkaCWYd5",
     "name": "pineapple pizza",
     "price": 45.75
   },
   "-NeAr6hwseNNLkaCWYd6": {
-    "firebaseKey": 5,
+    "firebaseKey": "-NeAr6hwseNNLkaCWYd6",
     "name": "supreme pizza",
     "price": 37.73
   },
   "-NeAr6hwseNNLkaCWYd7": {
-    "firebaseKey": 6,
+    "firebaseKey": "-NeAr6hwseNNLkaCWYd7",
     "name": "cheese pizza",
     "price": 5.92
   },
   "-NeAr6hwseNNLkaCWYd8": {
-    "firebaseKey": 7,
+    "firebaseKey": "-NeAr6hwseNNLkaCWYd8",
     "name": "hot boneless",
     "price": 21.55
   },
   "-NeAr6hwseNNLkaCWYd9": {
-    "firebaseKey": 8,
+    "firebaseKey": "-NeAr6hwseNNLkaCWYd9",
     "name": "pineapple pizza",
     "price": 3.35
   },
   "-NeAr6hxJ2IAocjcK1ak": {
-    "firebaseKey": 9,
+    "firebaseKey": "-NeAr6hxJ2IAocjcK1ak",
     "name": "supreme pizza",
     "price": 17.67
   },
   "-NeAr6hxJ2IAocjcK1al": {
-    "firebaseKey": 10,
+    "firebaseKey": "-NeAr6hxJ2IAocjcK1al",
     "name": "supreme pizza",
     "price": 23.29
   }

--- a/utils/sample_data/orders.json
+++ b/utils/sample_data/orders.json
@@ -1,6 +1,6 @@
 {
   "-NeAnv-2TQ0cbBsU4HYe": {
-    "firebaseKey": 1,
+    "firebaseKey": "-NeAnv-2TQ0cbBsU4HYe",
     "name": "Ilaire Botterell",
     "status": false,
     "phone": "895-201-6964",
@@ -8,7 +8,7 @@
     "ordertype": "walk-in"
   },
   "-NeAnv-3uHtOMWp56nTM": {
-    "firebaseKey": 2,
+    "firebaseKey": "-NeAnv-3uHtOMWp56nTM",
     "name": "Nanni Yakushkin",
     "status": false,
     "phone": "806-997-3008",
@@ -16,7 +16,7 @@
     "ordertype": "walk-in"
   },
   "-NeAnv-3uHtOMWp56nTN": {
-    "firebaseKey": 3,
+    "firebaseKey": "-NeAnv-3uHtOMWp56nTN",
     "name": "Baldwin Amberg",
     "status": true,
     "phone": "207-563-9309",
@@ -24,7 +24,7 @@
     "ordertype": "call-in"
   },
   "-NeAnv-4d5116_Shqzth": {
-    "firebaseKey": 4,
+    "firebaseKey": "-NeAnv-4d5116_Shqzth",
     "name": "Hewet Freckleton",
     "status": false,
     "phone": "257-964-6037",
@@ -32,7 +32,7 @@
     "ordertype": "walk-in"
   },
   "-NeAnv-4d5116_Shqzti": {
-    "firebaseKey": 5,
+    "firebaseKey": "-NeAnv-4d5116_Shqzti",
     "name": "Christos Josupeit",
     "status": false,
     "phone": "133-584-9897",
@@ -40,7 +40,7 @@
     "ordertype": "call-in"
   },
   "-NeAnv-58ORP_SAtO-FV": {
-    "firebaseKey": 6,
+    "firebaseKey": "-NeAnv-58ORP_SAtO-FV",
     "name": "Kennett Musselwhite",
     "status": false,
     "phone": "631-591-9469",
@@ -48,7 +48,7 @@
     "ordertype": "call-in"
   },
   "-NeAnv-58ORP_SAtO-FW": {
-    "firebaseKey": 7,
+    "firebaseKey": "-NeAnv-58ORP_SAtO-FW",
     "name": "Dukey Mance",
     "status": false,
     "phone": "680-437-6051",
@@ -56,7 +56,7 @@
     "ordertype": "walk-in"
   },
   "-NeAnv-6dHsrslIWt4XP": {
-    "firebaseKey": 8,
+    "firebaseKey": "-NeAnv-6dHsrslIWt4XP",
     "name": "Annecorinne Deane",
     "status": true,
     "phone": "792-889-9570",
@@ -64,7 +64,7 @@
     "ordertype": "call-in"
   },
   "-NeAnv-6dHsrslIWt4XQ": {
-    "firebaseKey": 9,
+    "firebaseKey": "-NeAnv-6dHsrslIWt4XQ",
     "name": "Kaitlin Bendixen",
     "status": false,
     "phone": "831-126-0990",
@@ -72,7 +72,7 @@
     "ordertype": "walk-in"
   },
   "-NeAnv-7EvXi3Kn8RgV4": {
-    "firebaseKey": 10,
+    "firebaseKey": "-NeAnv-7EvXi3Kn8RgV4",
     "name": "Flemming Joesbury",
     "status": true,
     "phone": "161-361-9806",


### PR DESCRIPTION
Delete button functionality works on Orders page

## Description
User can click the delete button and it will delete their order on the Orders Page
FirebaseKeys patched in items data and in orders data


## Motivation and Context
The user needs the ability to delete an order, if needed

## How Can This Be Tested?
click the 'delete' button on the orders card, and it should be removed from the page.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
