### PR TITLE
delete all orderitems fixed

### DIFF
--- a/api/mergedData.js
+++ b/api/mergedData.js
@@ -1,6 +1,6 @@
 import { getSingleItem } from './itemsData';
-import { getOrderItems } from './orderItems';
-import { getSingleOrder } from './ordersData';
+import { deleteItemOrder, getOrderItems } from './orderItems';
+import { deleteOrders, getSingleOrder } from './ordersData';
 
 // TO RENDER MY ORDER WITH ALL ORDERITEMS LISTED
 const getOrderDetails = async (orderId) => {
@@ -21,4 +21,13 @@ const getOrderDetails = async (orderId) => {
   // return allOrderItems;
 };
 
-export { getOrderDetails, getOrderItems };
+const deleteItemOrderRelationship = (firebaseKey) => new Promise((resolve, reject) => {
+  getOrderItems(firebaseKey).then((orderItemsArray) => {
+    const deleteItemPromises = orderItemsArray.map((item) => deleteItemOrder(item.firebaseKey));
+
+    Promise.all(deleteItemPromises).then(() => {
+      deleteOrders(firebaseKey).then(resolve);
+    });
+  }).catch(reject);
+});
+export { getOrderDetails, getOrderItems, deleteItemOrderRelationship };

--- a/events/domEvents.js
+++ b/events/domEvents.js
@@ -1,6 +1,6 @@
 import addOrderForm from '../components/forms/addOrderForm';
 /* eslint-disable no-alert */
-import { getOrders, deleteOrders, getSingleOrder } from '../api/ordersData';
+import { getOrders, getSingleOrder } from '../api/ordersData';
 import { showOrders } from '../pages/orders';
 import { getItems } from '../api/itemsData';
 import addItemsToOrder from '../components/forms/addItems';
@@ -8,7 +8,7 @@ import {
   createOrderItem, deleteItemOrder, getSingleItemOrder, updateOrderItems
 } from '../api/orderItems';
 import orderDetails from '../pages/showItems';
-import { getOrderDetails } from '../api/mergedData';
+import { deleteItemOrderRelationship, getOrderDetails } from '../api/mergedData';
 import closeOrderForm from '../components/forms/closeOrderForm';
 import { getRevenue } from '../api/revenueData';
 import revenue from '../pages/revenue';
@@ -22,7 +22,7 @@ const domEvents = (user) => {
     if (e.target.id.includes('order-delete')) {
       if (window.confirm('Do you want to delete?')) {
         const [, firebaseKey] = e.target.id.split('--');
-        deleteOrders(firebaseKey).then(() => {
+        deleteItemOrderRelationship(firebaseKey).then(() => {
           getOrders(user).then((array) => showOrders(array));
         });
       }


### PR DESCRIPTION
The items of the order get deleted (orderItems node) when we delete an order.

## Description
when the user deletes an order, the order and the items in that order get deleted.

## Related Issue

![Screenshot 2023-09-19 193016](https://github.com/nss-evening-cohort-24/pos-system-the-ronis/assets/119310701/107d48f8-85ff-4987-94b8-fc19f127f77d)

## Motivation and Context
the items need to be deleted in the orders, otherwise the database will keep compiling the items.

## How Can This Be Tested?
Look at the orders firebaseKey in your firebase and match it to the orderId in orderItems. When the order is deleted, the orderItems node and matching order will get deleted.



## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
